### PR TITLE
Support Nexus Update Check mod

### DIFF
--- a/MapSharingMadeEasy.cs
+++ b/MapSharingMadeEasy.cs
@@ -25,6 +25,7 @@ namespace MapSharingMadeEasy
         public string PluginVersion = "none";
         public static MapSharingMadeEasy instance;
         private static ConfigEntry<bool> modEnabled;
+        private static ConfigEntry<int> nexusID;
         private AssetBundle _assetBundle;
         private MapData _mapData;
 
@@ -45,6 +46,7 @@ namespace MapSharingMadeEasy
             Utils.Log($"MapSharingMadeEasy Version: {PluginVersion}");
             instance = this;
             modEnabled = Config.Bind("General", "Enabled", true, "Enable this mod");
+            nexusID = Config.Bind("General", "NexusID", 300, "Nexus mod ID for updates");
             Settings.Init(Config);
 
             if (!modEnabled.Value)


### PR DESCRIPTION
This adds support for the [Nexus Update Check mod](https://www.nexusmods.com/valheim/mods/102). I didn't put this in Settings.cs since that file seems to be dedicated to stuff that would need to be accessible elsewhere in the mod.